### PR TITLE
Use `loggings` for internal verbose logger setup

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "hatchling.build"
 [project]
 name = "lazyr"
 version = "0.1.0"
-dependencies = []
+dependencies = ["loggings"]
 requires-python = ">=3.12"
 authors = [
   {name = "Chitaoji", email = "2360742040@qq.com"},

--- a/src/lazyr/core.py
+++ b/src/lazyr/core.py
@@ -7,10 +7,11 @@ NOTE: this module is private. All functions and objects are available in the mai
 """
 
 import importlib
-import logging
 import sys
 import traceback
 from typing import TYPE_CHECKING, Any, Literal
+
+import loggings
 
 if TYPE_CHECKING:
     from types import ModuleType
@@ -223,7 +224,7 @@ class LazyModule:
 
         self.__name = name
         self.__submodules: set[str] = set()
-        self.__logger: logging.Logger | None = None
+        self.__logger = None
         self.__module: ModuleType | None = None
         self.__set_verbose(verbose)
         self.__ignore(submodules)
@@ -289,14 +290,7 @@ class LazyModule:
             self.__logger_init()
 
     def __logger_init(self) -> None:
-        logger = logging.getLogger("lazyr")
-        logger.propagate = False
-        if not logger.hasHandlers():
-            logger.setLevel(logging.DEBUG)
-            sh = logging.StreamHandler()
-            fm = logging.Formatter("%(levelname)s:%(name)s:%(message)s")
-            sh.setFormatter(fm)
-            logger.addHandler(sh)
+        logger = loggings.get_logger("lazyr", level=loggings.DEBUG)
         logger.info("register -> %s%s", self.__name, self.__get_frame_info(5))
         self.__logger = logger
 


### PR DESCRIPTION
### Motivation
- Replace ad-hoc logger setup in the lazy module implementation with the project's shared `loggings` utility to centralize formatting and coloring behavior.
- Ensure the runtime dependency is declared so the new logger integration is available to users.

### Description
- Import `loggings` in `src/lazyr/core.py` and replace the manual `logging` setup in `LazyModule.__logger_init` with `loggings.get_logger("lazyr", level=loggings.DEBUG)`.
- Remove the explicit `logging.Logger` type annotation on `self.__logger` and initialize it as `None` to match the new logger usage.
- Add `loggings` to project dependencies in `pyproject.toml` so the package is available at runtime.

### Testing
- Ran `python -m compileall src` to verify the package compiles, and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b4f4005248832abd4a8efb1c664d95)